### PR TITLE
stg の URL の末尾の "/" が抜けていた。

### DIFF
--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -36,5 +36,5 @@ jobs:
             owner: context.repo.owner,
             repo: context.repo.repo,
             body: 'Deployed on https://iij.github.io/seil2recipe-stg/' +
-                  '${{ github.event.pull_request.number }}'
+                  '${{ github.event.pull_request.number }}' + '/'
           })


### PR DESCRIPTION
GitHub Pages は自動的にリダイレクトしないようだ。