### PR TITLE
URL 末尾の /index.html を明示してみる。

### DIFF
--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -36,5 +36,5 @@ jobs:
             owner: context.repo.owner,
             repo: context.repo.repo,
             body: 'Deployed on https://iij.github.io/seil2recipe-stg/' +
-                  '${{ github.event.pull_request.number }}' + '/'
+                  '${{ github.event.pull_request.number }}' + '/index.html'
           })


### PR DESCRIPTION
iij/seil2recipe-stg の GitHub Pages が deloy される前にアクセスすると 404 になり、deploy が完了してもその状態がどこかにキャッシュされるような挙動が見える。URL 末尾の index.html を明示することで回避可能か試してみる。