### PR TITLE
nat snapt add default はサポートされていない。

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -1343,7 +1343,6 @@ describe('nat', () => {
                 'nat.ipv4.snapt.100.interface: vlan0',
                 'nat.ipv4.snapt.100.protocol: 41'
             ]);
-
     });
 
     it('static', () => {


### PR DESCRIPTION
 - nat snapt の構文解釈に read_params を使うよう書き直した。
 - nat snapt add default に対しては notsupported エラーを出す。