### PR TITLE
seil6 4.93 対応

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,8 +35,8 @@
       <div class="config-row">
         <div class="model">To:
           <select id="model-dst" v-model="selected">
-            <option value="w2">SA-W2 (4.91)</option>
-            <option value="w2l">SA-W2L (4.91)</option>
+            <option value="w2">SA-W2 (4.93)</option>
+            <option value="w2l">SA-W2L (4.93)</option>
             <option value="x4" selected>SEIL/X4 (2.40)</option>
             <option value="ayame">SEIL/x86 Ayame (2.40)</option>
           </select>

--- a/seil2recipe.js
+++ b/seil2recipe.js
@@ -602,6 +602,7 @@ const CompatibilityList = {
     'option ipv6 fragment-requeueing off':             [    0,    1 ],
     'option ipv6 monitor-linkstate off':               [    0,    1 ],
     'option ipv6 redirects on':                        [    0,    1 ],
+    'pppac l2tp accept-dialin':                        [    1,    0 ],
     'pppac option session-limit off':                  [    0,    1 ],
     'route dynamic rip':                               [    0,    1 ],
     'route6 dynamic ospf':                             [    0,    1 ],
@@ -2250,6 +2251,9 @@ Converter.rules['interface'] = {
                 });
 
                 const k1 = `interface.${ifname}`;
+                if (!conv.missing('pppac l2tp accept-dialin')) {
+                    conv.param2recipe(protocol, 'accept-dialin', `${k1}.l2tp.accept-dialin`, on2enable);
+                }
                 if (protocol['accept-interface'] != 'any') {
                     (protocol['accept-interface'] || "").split(',').forEach(name => {
                         const k2 = conv.get_index(`${k1}.l2tp.accept`);
@@ -3738,9 +3742,9 @@ Converter.rules['pppac'] = {
         'l2tp': {
             'add': (conv, tokens) => {
                 const params = conv.read_params('pppac.protocol', tokens, 4, {
+                    'accept-dialin': true,
                     'accept-interface': true,
                     'authentication-method': true,
-                    'accept-dialin': true,
                     'authentication-timeout': true,
                     'mppe' :true,
                     'mppe-key-length': true,

--- a/seil2recipe.js
+++ b/seil2recipe.js
@@ -593,7 +593,6 @@ const CompatibilityList = {
     'ipsec security-association add ... ipv6':         [    0,    1 ],
     'interface ... add dhcp6':                         [    0,    1 ],
     'interface ... add router-advertisement(s)':       [    0,    1 ],
-    'nat.ipv4.napt.[].global':                         [    0,    1 ],
     'nat6':                                            [    0,    1 ],
     'option ip fragment-requeueing off':               [    0,    1 ],
     'option ip monitor-linkstate off':                 [    0,    1 ],
@@ -3354,8 +3353,6 @@ Converter.rules['nat'] = {
                         return;
                     } else if (napt.ifnames.size == 1) {
                         conv.add(`nat.ipv4.napt.global`, napt.global.addr);
-                    } else if (conv.missing("nat.ipv4.napt.[].global", true)) {
-                        conv.warning(`${conv.devname} では global アドレスをインタフェースごとに設定することはできません。`);
                     } else {
                         napts.forEach(pair => {
                             const [prefix, conv] = pair;

--- a/test/test.js
+++ b/test/test.js
@@ -1774,7 +1774,7 @@ describe('pppac', () => {
             pppac pool add POOL5A address 192.168.2.0/24
             pppac ipcp-configuration add IPCP5L pool POOL5L
             pppac ipcp-configuration add IPCP5A pool POOL5A
-            pppac protocol l2tp add PROTO5L accept-interface vlan0 authentication-method pap,chap,mschapv2
+            pppac protocol l2tp add PROTO5L accept-interface vlan0 authentication-method pap,chap,mschapv2 accept-dialin on
             pppac protocol l2tp add PROTO5A accept-interface vlan1 authentication-method mschapv2
             interface pppac0 ipcp-configuration IPCP5L
             interface pppac0 bind-tunnel-protocol PROTO5L
@@ -1793,6 +1793,7 @@ describe('pppac', () => {
             interface.pppac0.ipcp.pool.100.count: 256
             interface.pppac0.ipv4.address: 192.168.0.1
             interface.pppac0.l2tp.accept.100.interface: vlan0
+            interface.pppac0.l2tp.accept-dialin: enable
             interface.pppac0.l2tp.authentication.100.method: pap
             interface.pppac0.l2tp.authentication.200.method: chap
             interface.pppac0.l2tp.authentication.300.method: mschapv2


### PR DESCRIPTION
- interface.pppac[].l2tp.accept-dialin
- nat.ipv4.napt.[].global
- nat.ipv4.snapt.[].listen.address

など。他は CompatibilityList に入れていなかったため変更不要。
