### PR TITLE
seil3 7.07 対応

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,7 +23,7 @@
   <div>
     <div class="config-area">
       <div id="seilconfig" class="config-row">
-        <div class="model">From: SEIL/X1, X2, B1, x86 Fuji, BPV4 (7.05)</div>
+        <div class="model">From: SEIL/X1, X2, B1, x86 Fuji, BPV4 (7.07)</div>
         <textarea class="config-text" v-model="text" rows="20" cols="64" spellcheck="false"
           placeholder="Enter SEIL config here."></textarea>
       </div>

--- a/seil2recipe.js
+++ b/seil2recipe.js
@@ -1026,10 +1026,14 @@ Converter.rules['bridge'] = {
             const bridge_if = conv.get_named_index('bridge');
             const params = conv.read_params('bridge.group', tokens, 3, {
                 'aging-time': 'notsupported',
+                'default-bridging': true,
                 'forward-delay': true,
                 'hello-time': true,
                 'loop-detection': 'notsupported',
+                'ip-bridging': true,
+                'ipv6-bridging': true,
                 'max-age': true,
+                'pppoe-bridging': true,
                 'priority': true,
                 'stp': true,
             });
@@ -1053,6 +1057,20 @@ Converter.rules['bridge'] = {
                 if (params['priority']) {
                     conv.notsupported('priority');
                 }
+            }
+
+            const k = `interface.${bridge_if}.forward`;
+            if (params['ip-bridging'] == 'off') {
+                conv.add(`${k}.ipv4`, 'disable');
+            }
+            if (params['ipv6-bridging'] == 'off') {
+                conv.add(`${k}.ipv6`, 'disable');
+            }
+            if (params['pppoe-bridging'] == 'off') {
+                conv.add(`${k}.pppoe`, 'disable');
+            }
+            if (params['default-bridging'] == 'off') {
+                conv.add(`${k}.other`, 'disable');
             }
         }
     },

--- a/seil2recipe.js
+++ b/seil2recipe.js
@@ -3628,6 +3628,11 @@ Converter.rules['option'] = {
             conv.set_memo('option.ipv4.send-icmp-redirect.service',
                 [ conv, on2enable(tokens[3]) ]);
         },
+        'recursive-lookup': (conv, tokens) => {
+            if (tokens[3] != 'off') {
+                conv.notsupported();
+            }
+        },
         'unicast-rpf': (conv, tokens) => {
             if (tokens[3] != 'none') {
                 conv.notsupported();

--- a/test/test.js
+++ b/test/test.js
@@ -241,6 +241,19 @@ describe('bridge', () => {
             ]);
     });
 
+    it('bridge group parameters', () => {
+        assertconv(`
+            bridge group add BG ip-bridging off ipv6-bridging off pppoe-bridging off default-bridging off
+            bridge interface lan1 group BG
+            ---
+            interface.bridge0.member.100.interface: ge0
+            interface.bridge0.forward.ipv4: disable
+            interface.bridge0.forward.ipv6: disable
+            interface.bridge0.forward.pppoe: disable
+            interface.bridge0.forward.other: disable
+        `);
+    });
+
     // see filter tests for "bridge filter on"
 
     it('vman-tpid is not supported.', () => {


### PR DESCRIPTION
- option ip recursive-lookup {off|tunnel-gw} が追加された。
- bridge group にも {ip,ipv6,pppoe,default}-bridging を設定できるようになった。
