### PR TITLE
seil6 5.20 対応

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,7 +35,7 @@
       <div class="config-row">
         <div class="model">To:
           <select id="model-dst" v-model="selected">
-            <option value="w2">SA-W2, W2L, W2S (5.11)</option>
+            <option value="w2">SA-W2, W2L, W2S (5.20)</option>
             <option value="x4" selected>SEIL/X4 (2.53)</option>
             <option value="ayame">SEIL/x86 Ayame (2.53)</option>
           </select>

--- a/seil2recipe.js
+++ b/seil2recipe.js
@@ -607,7 +607,6 @@ const CompatibilityList = {
     'sshd authorized-key admin':                       [    0,    1 ],
     'sshd hostkey':                                    [    0,    1 ],
     'sshd password-authentication enable':             [    0,    1 ],
-    'syslog memory-block':                             [    0,    1 ],
     'syslog remote ipv6':                              [    0,    1 ],
     'telnetd':                                         [    0,    1 ],
     'upnp.listen.[].interface':                        [    0,    1 ],
@@ -4819,7 +4818,6 @@ Converter.rules['syslog'] = {
 
     'memory-block': (conv, tokens) => {
         // syslog memory-block <function> { <blocks> | system-default }
-        if (conv.missing('syslog memory-block')) { return; }
         const oldfun = tokens[2] || '???';
         var newfun = oldfun;
         switch (oldfun) {


### PR DESCRIPTION
- syslog.memory-block が設定できるようになった。
