### PR TITLE
seil6 5.21 対応

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,7 +35,7 @@
       <div class="config-row">
         <div class="model">To:
           <select id="model-dst" v-model="selected">
-            <option value="w2">SA-W2, W2L, W2S (5.20)</option>
+            <option value="w2">SA-W2, W2L, W2S (5.21)</option>
             <option value="x4" selected>SEIL/X4 (2.53)</option>
             <option value="ayame">SEIL/x86 Ayame (2.53)</option>
           </select>

--- a/seil2recipe.js
+++ b/seil2recipe.js
@@ -600,6 +600,7 @@ const CompatibilityList = {
     'option ipv6 fragment-requeueing off':             [    0,    1 ],
     'option ipv6 monitor-linkstate off':               [    0,    1 ],
     'option ipv6 redirects on':                        [    0,    1 ],
+    'ppp authentication-method none':                  [    1,    0 ],
     'pppac option session-limit off':                  [    0,    1 ],
     'route dynamic rip':                               [    0,    1 ],
     'route6 dynamic ospf':                             [    0,    1 ],
@@ -2554,6 +2555,19 @@ Converter.rules['interface'] = {
             conv.param2recipe(params, 'tcp-mss6', `${k1}.ipv6.tcp-mss`);
             conv.param2recipe(params, 'keepalive', `${k1}.keepalive`);
 
+            // authentication-method
+            const am = params['authentication-method'];
+            if (am) {
+                if (am == 'auto') {
+                    // it's default.
+                } else if (am == 'none' && ifname.match(/^ppp\d+$/) &&
+                    !conv.missing('ppp authentication-method none', true)) {
+                    conv.param2recipe(params, 'authentication-method', `${k1}.auth-method`);
+                } else {
+                    conv.notsupported(`ppp authentication-method ${params['authentication-method']}`);
+                }
+            }
+
             // auto-connect
             if (ifname.match(/^ppp\d+$/)) {
                 if (params['auto-connect'] == 'vrrp') {
@@ -3715,9 +3729,6 @@ Converter.rules['ppp'] = {
             'idle-timer': true,
             'mppe': 'notsupported'
         });
-        if (['chap', 'none', 'pap'].includes(params['authentication-method'])) {
-            conv.notsupported(`ppp authentication-method ${params['authentication-method']}`);
-        }
     },
 };
 

--- a/test/test.js
+++ b/test/test.js
@@ -1763,6 +1763,23 @@ describe('option', () => {
     });
 });
 
+describe('ppp', () => {
+    it('ppp interface, authentication-method none', () => {
+        assertconv(`
+            ppp add PPP ipcp enable authentication-method none
+            dialup-device access-point add AP cid 2
+            dialup-device foma0 connect-to AP
+            interface ppp0 over foma0
+            interface ppp0 ppp-configuration PPP
+            ---
+            interface.ppp0.dialup-device: foma0
+            interface.ppp0.cid: 2
+            interface.ppp0.ipcp: enable
+            interface.ppp0.auth-method: none
+        `);
+    });
+});
+
 describe('pppac', () => {
     it('option', () => {
         assertconv('pppac option session-limit on',


### PR DESCRIPTION
- interface.ppp[].auth-method が書けるようになった。
