### PR TITLE
CA10 対応

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # SEIL Legacy Config to Recipe Config Converter
 ![](https://github.com/iij/seil2recipe/workflows/test/badge.svg)
 
-[SEILコンフィグ自動変換ツール](https://iij.github.io/seil2recipe/) は SEIL/X1, X2, B1, BPV4, x86 Fuji の設定(旧コンフィグ)を SEIL/X4, SEIL/x86 Ayame, SA-W2, SA-W2L, SA-W2S の設定(レシピコンフィグ)に変換するツールです。
+[SEILコンフィグ自動変換ツール](https://iij.github.io/seil2recipe/) は SEIL/X1, X2, B1, BPV4, x86 Fuji の設定(旧コンフィグ)を SEIL/X4, SEIL/x86 Ayame, SEIL CA10, SA-W2, SA-W2L, SA-W2S の設定(レシピコンフィグ)に変換するツールです。
 
 
 ## 使い方

--- a/index.html
+++ b/index.html
@@ -36,8 +36,8 @@
         <div class="model">To:
           <select id="model-dst" v-model="selected">
             <option value="w2">SA-W2, W2L, W2S (5.33)</option>
-            <option value="x4" selected>SEIL/X4 (2.71)</option>
-            <option value="ayame">SEIL/x86 Ayame (2.71)</option>
+            <option value="x4" selected>SEIL/X4 (3.00)</option>
+            <option value="ayame">SEIL/x86 Ayame (3.00)</option>
           </select>
         </div>
         <textarea id="recipeconfig" class="config-text" v-model="text" rows="20" cols="64" spellcheck="false"

--- a/index.html
+++ b/index.html
@@ -38,6 +38,7 @@
             <option value="w2">SA-W2, W2L, W2S (5.33)</option>
             <option value="x4" selected>SEIL/X4 (3.00)</option>
             <option value="ayame">SEIL/x86 Ayame (3.00)</option>
+            <option value="ca10">SEIL CA10 (3.00)</option>
           </select>
         </div>
         <textarea id="recipeconfig" class="config-text" v-model="text" rows="20" cols="64" spellcheck="false"

--- a/index.html
+++ b/index.html
@@ -88,15 +88,16 @@
         text: `hostname ""
 timezone "Japan"
 environment login-timer 300
-ppp add PPPOE-SAMPLE keepalive 30 ipcp enable ipcp-address on ipcp-dns on ipv6cp enable authentication-method chap identifier "" tcp-mss auto
+option ip monitor-linkstate on
+option ip update-connected-route on
+option ipv6 monitor-linkstate on
+option ipv6 update-connected-route on
+ppp add pppoe-sample keepalive 30 ipcp enable ipcp-address on ipcp-dns on ipv6cp enable authentication-method chap identifier "" tcp-mss auto
 interface lan0 media auto
 interface lan0 add 192.168.0.1/24
 interface lan1 media auto
 interface lan1 queue normal
 interface lan2 media auto
-interface lan3 media auto
-interface lan4 media auto
-interface lan5 media auto
 interface pppoe0 over lan1
 bridge disable
 bridge ip-bridging on
@@ -116,10 +117,10 @@ route6 dynamic ripng disable
 route6 dynamic redistribute static-to-ripng disable
 route6 dynamic redistribute connected-to-ripng enable
 route6 dynamic pim-sparse disable
-filter add seil_ctl_lan0 interface lan0 direction in action pass protocol tcp src 192.168.0.0/24 srcport 0-65535 dst self dstport 0-65535 state disable logging off enable
+filter add seil_ctl_lan0 interface lan0 direction in action pass protocol tcp srcport 0-65535 dst self dstport 0-65535 state disable logging off enable
 filter add telnetd_block interface any direction in action block protocol tcp srcport 0-65535 dst self dstport 23 state disable logging on enable
 filter add httpd_block interface any direction in action block protocol tcp srcport 0-65535 dst self dstport 80 state disable logging on enable
-filter6 add seil_ctl_lan0 interface lan0 direction in action pass protocol tcp src fe80::/10 srcport 0-65535 dst self dstport 0-65535 state disable logging off enable
+filter6 add seil_ctl_lan0 interface lan0 direction in action pass protocol tcp srcport 0-65535 dst self dstport 0-65535 state disable logging off enable
 filter6 add telnetd_block interface any direction in action block protocol tcpudp srcport 0-65535 dst self dstport 23 state disable logging on enable
 filter6 add httpd_block interface any direction in action block protocol tcpudp srcport 0-65535 dst self dstport 80 state disable logging on enable
 nat timeout 900

--- a/seil2recipe.js
+++ b/seil2recipe.js
@@ -2451,16 +2451,29 @@ Converter.rules['interface'] = {
         'media': (conv, tokens) => {
             const ifname = conv.ifmap(tokens[1]);
             let media = tokens[3];
-            if (conv.devname != 'SEIL/x86 Ayame') {
+            if (conv.devname == 'SEIL/x86 Ayame') {
+                if (media != 'auto') {
+                    conv.notsupported(`media ${media}`);
+                }
+                conv.add(`interface.${ifname}.media`, 'auto');
+            } else {
                 switch (ifname) {
                     case 'ge0':
-                        conv.add('interface.ge0p0.media', media);
+                        if (conv.devname == 'SEIL CA10') {
+                            conv.add('interface.ge0.media', media);
+                        } else {
+                            conv.add('interface.ge0p0.media', media);
+                        }
                         break;
                     case 'ge1':
-                        conv.add('interface.ge1p0.media', media);
-                        conv.add('interface.ge1p1.media', media);
-                        conv.add('interface.ge1p2.media', media);
-                        conv.add('interface.ge1p3.media', media);
+                        if (conv.devname == 'SEIL CA10') {
+                            conv.add('interface.ge1.media', media);
+                        } else {
+                            conv.add('interface.ge1p0.media', media);
+                            conv.add('interface.ge1p1.media', media);
+                            conv.add('interface.ge1p2.media', media);
+                            conv.add('interface.ge1p3.media', media);
+                        }
                         break;
                     case 'ge2':
                         if (conv.devname.startsWith('SA-')) {
@@ -2474,12 +2487,18 @@ Converter.rules['interface'] = {
                         }
                         conv.add('interface.ge2.media', media);
                         break;
+                    case 'ge4':
+                    case 'ge5':
+                        if (media != '1000baseT-FDX' && media != 'auto') {
+                            conv.notsupported(`${ifname} media ${media}`);
+                            media = 'auto';
+                        }
+                        conv.add(`interface.${ifname}.media`, media);
+                        break;
+                    default:
+                        conv.add(`interface.${ifname}.media`, media);
+                        break;
                 }
-            } else {  // Ayame
-                if (media != 'auto') {
-                    conv.notsupported(`media ${media}`);
-                }
-                conv.add(`interface.${ifname}.media`, 'auto');
             }
         },
 

--- a/seil2recipe.js
+++ b/seil2recipe.js
@@ -151,15 +151,27 @@ class Note {
         this.memo.set('qos.class', { 'default': 'root' });
         this.memo.set('resolver.address', []);
 
-        this.if_mappings = {
-            'lan0': 'ge1',
-            'lan1': 'ge0',
-            'lan2': 'ge2',
-            'lan3': 'ge3',
-            'lan4': 'ge4',
-            'lan5': 'ge5',
-            'lan*': 'ge*'
-        };
+        if (target_device != 'ca10') {
+            this.if_mappings = {
+                'lan0': 'ge1',
+                'lan1': 'ge0',
+                'lan2': 'ge2',
+                'lan3': 'ge3',
+                'lan4': 'ge4',
+                'lan5': 'ge5',
+                'lan*': 'ge*'
+            };
+        } else {
+            this.if_mappings = {  // CA10
+                'lan0': 'ge5',
+                'lan1': 'ge4',
+                'lan2': 'ge0',
+                'lan3': 'ge1',
+                'lan4': 'ge2',
+                'lan5': 'ge3',
+                'lan*': 'ge*'
+            };
+        }
 
         //
         // Notes for tangled config parameters
@@ -571,6 +583,7 @@ class Device {
             'w2':    'SA-W2',
             'x4':    'SEIL/X4',
             'ayame': 'SEIL/x86 Ayame',
+            'ca10':  'SEIL CA10',
         }[shortname];
     }
 }

--- a/seil2recipe.js
+++ b/seil2recipe.js
@@ -25,10 +25,10 @@
  */
 
 class Converter {
-    constructor(seilconfig, dst) {
+    constructor(seilconfig, target_device) {
         this.seilconfig  = seilconfig;
         this.conversions = [];
-        this.note        = new Note(dst);
+        this.note        = new Note(target_device);
 
         this.convert();
     }
@@ -134,13 +134,13 @@ Converter.defers = [];
 
 
 class Note {
-    constructor(dst) {
+    constructor(target_device) {
         this.indices = new Map();  // (prefix) -> (last index number)
         this.params  = new Map();
         this.ifindex = new Map();  // (prefix) -> (interface) -> (index)
         this.memo    = new Map();
         this.deps    = new DependencySet();
-        this.dst     = new Device(dst);
+        this.dst     = new Device(target_device);
 
         this.memo.set('bridge.group', new Map());
         this.memo.set('floatlink.interfaces', []);
@@ -257,8 +257,8 @@ class Conversion {
     //
     // Conversion Utility
     //
-    ifmap(new_name) {
-        return this.note.if_mappings[new_name] || new_name;
+    ifmap(old_name) {
+        return this.note.if_mappings[old_name] || old_name;
     }
 
     set_ifmap(old_name, new_name) {

--- a/test/test.js
+++ b/test/test.js
@@ -2652,6 +2652,24 @@ describe('seil6', () => {
     });
 });
 
+describe('ca10', () => {
+    it('can be a target device', () => {
+        const c = new s2r.Converter('hostname foo\n', 'ca10');
+        assert.match(c.recipe_config, /^hostname: foo$/m);
+    });
+
+    it('ge4 is connected to upstream"', () => {
+        const c = new s2r.Converter(`
+            interface lan0 add 192.168.0.1/24
+            interface lan1 add dhcp
+            interface lan2 add 2001:db8::2/64
+        `, 'ca10');
+        assert.match(c.recipe_config, /^interface.ge4.ipv4.address: dhcp$/m);
+        assert.match(c.recipe_config, /^interface.ge5.ipv4.address: 192.168.0.1\/24$/m);
+        assert.match(c.recipe_config, /^interface.ge0.ipv6.address: 2001:db8::2\/64$/m);
+    });
+});
+
 describe('factory-config', () => {
     it('should be converted without script error', () => {
         const buf = fs.readFileSync('index.html');


### PR DESCRIPTION
変換対象に SEIL CA10 を追加する。同時に seil8 系ファームウェア 3.00 に対応する。

CA10 対応における留意点は、WAN 側インタフェースを ge4 に、LAN 側インタフェースを ge5 としたこと。CA10 の Ethernet インタフェースは、ge0 - ge3 は 1G で、ge4 と ge5 が 10G である。SMF の Pull に用いるインタフェースは ge4 なので、ge4 を WAN 側インタフェースとするのが基本的な接続構成である。また CA10 を導入する場合は 10G の回線速度を使い切るために LAN 側にも 10G スイッチを接続することが想定される。したがって LAN 側インタフェースは ge0-3 ではなく ge5 とした。