### PR TITLE
seil3/6/8 7.31/5.52/3.31 対応

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,7 +23,7 @@
   <div>
     <div class="config-area">
       <div id="seilconfig" class="config-row">
-        <div class="model">From: SEIL/X1, X2, B1, x86 Fuji, BPV4 (7.21)</div>
+        <div class="model">From: SEIL/X1, X2, B1, x86 Fuji, BPV4 (7.31)</div>
         <textarea class="config-text" v-model="text" rows="20" cols="64" spellcheck="false"
           placeholder="Enter SEIL config here."></textarea>
       </div>
@@ -35,10 +35,10 @@
       <div class="config-row">
         <div class="model">To:
           <select id="model-dst" v-model="selected">
-            <option value="w2">SA-W2, W2L, W2S (5.50)</option>
-            <option value="x4" selected>SEIL/X4 (3.30)</option>
-            <option value="ayame">SEIL/x86 Ayame (3.30)</option>
-            <option value="ca10">SEIL CA10 (3.30)</option>
+            <option value="w2">SA-W2, W2L, W2S (5.52)</option>
+            <option value="x4" selected>SEIL/X4 (3.31)</option>
+            <option value="ayame">SEIL/x86 Ayame (3.31)</option>
+            <option value="ca10">SEIL CA10 (3.31)</option>
           </select>
         </div>
         <textarea id="recipeconfig" class="config-text" v-model="text" rows="20" cols="64" spellcheck="false"

--- a/seil2recipe.js
+++ b/seil2recipe.js
@@ -587,7 +587,7 @@ const CompatibilityList = {
     'dhcp6 relay':                                     [    0,    1 ],
     'dhcp6 server':                                    [    0,    1 ],
     'dialup-device ... device-option ux312nc-3g-only': [    1,    0 ],
-    'dialup-device ... device-option ux312nc-lte-only':[    0,    0 ],
+    'dialup-device ... device-option ux312nc-lte-only':[    1,    0 ],
     'dialup-network':                                  [    1,    0 ],
     'filter6 add ... action forward':                  [    0,    1 ],
     'ike peer add ... check-level':                    [    0,    1 ],
@@ -2753,7 +2753,9 @@ Converter.rules['interface'] = {
                 }
 
                 if (ddev['ux312nc-lte-only'] != null) {
-                    conv.missing('dialup-device ... device-option ux312nc-lte-only');
+                    if (!conv.missing('dialup-device ... device-option ux312nc-lte-only')) {
+                        conv.add(`${k1}.device-option.ux312nc-lte-only`, ddev['ux312nc-lte-only']);
+                    }
                 }
 
                 const apname = ddev['connect-to'];

--- a/seil2recipe.js
+++ b/seil2recipe.js
@@ -4641,11 +4641,13 @@ Converter.rules['route'] = {
                 'exact-match': 0,
                 'interface': true,
                 'metric': true,
+                'tag': 'notsupported',
                 'pass':  0,
                 'block': 0,
                 'set-as-path-prepend': true,
                 'set-metric': true,
                 'set-metric-type': true,
+                'set-tag': 'notsupported',
                 'set-weight': true,
             });
         },

--- a/test/test.js
+++ b/test/test.js
@@ -568,7 +568,6 @@ describe('dialup-device', () => {
             ppp add PPP ipcp enable ipcp-address on ipcp-dns on ipv6cp enable identifier pppuser@mobile.example.jp passphrase ppppass keepalive 8 auto-connect ondemand idle-timer 30
             dialup-device access-point add AP cid 2 apn example.jp pdp-type ip
             dialup-device mdm0 connect-to AP pin 1234 auto-reset-fail-count 10
-            dialup-device mdm0 device-option ux312nc-3g-only on
             dialup-device keepalive-send-interval 30
             dialup-device keepalive-down-count 20
             dialup-device keepalive-timeout 3
@@ -581,7 +580,6 @@ describe('dialup-device', () => {
             interface.ppp0.auto-reset-keepalive.down-detect-time: 10
             interface.ppp0.auto-reset-keepalive.reply-timeout: 3
             interface.ppp0.cid: 2
-            interface.ppp0.device-option.ux312nc-3g-only: enable
             interface.ppp0.dialup-device: mdm0
             interface.ppp0.id: pppuser@mobile.example.jp
             interface.ppp0.idle-timer: 30
@@ -615,16 +613,29 @@ describe('dialup-device', () => {
         `);
     });
 
-    it('ux312nc-lte-only is not supported on seil6/seil8 yet', () => {
+    it('ux312nc-lte-only is not supported on seil8', () => {
+        assertconv(`
+            dialup-device access-point add AP apn example.jp
+            dialup-device mdm0 connect-to AP
+            dialup-device mdm0 authentication-method chap username foo password bar
+            dialup-device mdm0 device-option ux312nc-lte-only enable
+            interface wwan0 over mdm0
+            ---
+            interface.wwan0.apn: example.jp
+            interface.wwan0.auth-method: chap
+            interface.wwan0.dialup-device: mdm0
+            interface.wwan0.id: foo
+            interface.wwan0.password: bar
+            interface.wwan0.device-option.ux312nc-lte-only: enable
+        `, 'w2');
+
         // warning: incomplete config.
         const config_e = `dialup-device mdm0 device-option ux312nc-lte-only enable
                           interface ppp0 over mdm0`;
-        assert_notsupported(config_e, 'w2');
         assert_notsupported(config_e, 'x4');
 
         const config_d = `dialup-device mdm0 device-option ux312nc-lte-only disable
                           interface ppp0 over mdm0`;
-        assert_notsupported(config_d, 'w2');
         assert_notsupported(config_d, 'x4');
     });
 });

--- a/test/test.js
+++ b/test/test.js
@@ -2414,6 +2414,11 @@ describe('route', () => {
             `);
         });
     });
+
+    it('does not support "route-filter tag / set-tag"', () => {
+        assert_notsupported("route dynamic route-filter add A tag 1");
+        assert_notsupported("route dynamic route-filter add B set-tag 1");
+    });
 });
 
 describe('route6', () => {


### PR DESCRIPTION
- device-option ux312nc-lte-only の変換に対応した。
- route-filter ... tag / set-tag は seil6/8 では利用できないため警告を出す。